### PR TITLE
support Type::Tiny

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'perl', '5.008001';
 
 requires 'Carp';
+requires 'Module::Load';
 requires 'Mouse::Util::TypeConstraints';
 
 on 'test' => sub {

--- a/lib/Class/Accessor/Typed.pm
+++ b/lib/Class/Accessor/Typed.pm
@@ -4,14 +4,14 @@ use strict;
 use warnings;
 
 use Carp;
-use Mouse::Util::TypeConstraints ();
+use Module::Load qw( load );
+
+use Class::Accessor::Typed::Mouse;
 
 our $VERSION = "0.03";
-
-*_get_isa_type_constraint  = \&Mouse::Util::TypeConstraints::find_or_create_isa_type_constraint;
-*_get_does_type_constraint = \&Mouse::Util::TypeConstraints::find_or_create_does_type_constraint;
-
 our $VERBOSE = 1;
+
+our $TYPE_CLASS = 'Class::Accessor::Typed::Mouse';
 
 my %key_ctor = (
     rw      => \&_mk_accessors,
@@ -27,6 +27,11 @@ sub import {
 
     my %rules;
 
+    if (exists $args{type}) {
+        $TYPE_CLASS = 'Class::Accessor::Typed::' . $args{type};
+        load($TYPE_CLASS);
+    }
+
     for my $key (sort keys %key_ctor) {
         if (defined $args{$key}) {
             croak("value of the '$key' parameter should be an hashref") unless ref($args{$key}) eq 'HASH';
@@ -37,9 +42,9 @@ sub import {
 
                 $rule->{type} = do {
                     if (defined $rule->{isa}) {
-                        _get_isa_type_constraint($rule->{isa});
+                        $TYPE_CLASS->type($rule->{isa});
                     } elsif (defined $rule->{does}) {
-                        _get_does_type_constraint($rule->{does});
+                        $TYPE_CLASS->type_role($rule->{isa});
                     }
                 };
                 $rule->{lazy} = ($key eq 'rw_lazy' or $key eq 'ro_lazy') ? 1 : 0;

--- a/lib/Class/Accessor/Typed.pm
+++ b/lib/Class/Accessor/Typed.pm
@@ -6,8 +6,6 @@ use warnings;
 use Carp;
 use Module::Load qw( load );
 
-use Class::Accessor::Typed::Mouse;
-
 our $VERSION = "0.03";
 our $VERBOSE = 1;
 
@@ -29,8 +27,8 @@ sub import {
 
     if (exists $args{type}) {
         $TYPE_CLASS = 'Class::Accessor::Typed::' . $args{type};
-        load($TYPE_CLASS);
     }
+    load($TYPE_CLASS);
 
     for my $key (sort keys %key_ctor) {
         if (defined $args{$key}) {

--- a/lib/Class/Accessor/Typed/Mouse.pm
+++ b/lib/Class/Accessor/Typed/Mouse.pm
@@ -1,0 +1,21 @@
+package Class::Accessor::Typed::Mouse;
+use strict;
+use warnings;
+use utf8;
+
+use Mouse::Util::TypeConstraints ();
+
+*_get_isa_type_constraint  = \&Mouse::Util::TypeConstraints::find_or_create_isa_type_constraint;
+*_get_does_type_constraint = \&Mouse::Util::TypeConstraints::find_or_create_does_type_constraint;
+
+sub type {
+    my ($class, $type_name) = @_;
+    return _get_isa_type_constraint($type_name);
+}
+
+sub type_role {
+    my ($class, $type_name) = @_;
+    return _get_does_type_constraint($type_name);
+}
+
+1;

--- a/lib/Class/Accessor/Typed/TypeTiny.pm
+++ b/lib/Class/Accessor/Typed/TypeTiny.pm
@@ -1,0 +1,46 @@
+package Class::Accessor::Typed::TypeTiny;
+use strict;
+use warnings;
+use utf8;
+
+use Scalar::Util qw/blessed/;
+use Type::Registry;
+use Type::Utils;
+
+my $reg = Type::Registry->for_class(__PACKAGE__);
+
+sub type {
+    my ($class, $type_name) = @_;
+    return $type_name if blessed($type_name);
+
+    if (my $type = $reg->simple_lookup($type_name)) {
+        return $type;
+    } else {
+        my $type = Type::Utils::dwim_type(
+            $type_name,
+            fallback => [ 'lookup_via_mouse', 'make_class_type' ],
+        );
+        $type->{display_name} = $type_name;
+        $reg->add_type($type, $type_name);
+        return $type;
+    }
+}
+
+sub type_role {
+    my ($class, $type_name) = @_;
+    return $type_name if blessed($type_name);
+
+    if (my $type = $reg->simple_lookup($type_name)) {
+        return $type;
+    } else {
+        my $type = Type::Utils::dwim_type(
+            $type_name,
+            fallback => ['make_role_type'],
+        );
+        $type->{display_name} = $type_name;
+        $reg->add_type($type, $type_name);
+        return $type;
+    }
+}
+
+1;

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -3,6 +3,8 @@ use Test::More 0.98;
 
 use_ok $_ for qw(
     Class::Accessor::Typed
+    Class::Accessor::Typed::Mouse
+    Class::Accessor::Typed::TypeTiny
 );
 
 done_testing;


### PR DESCRIPTION
Class::Accessor::Typed uses Mouse::Util::TypeConstraints, but some case required to use Type::Tiny.
This pull request is prototype of supporting Type::Tiny on this module.

### Discussion

In this code, Type::Tiny enables like this:

```perl
use Class::Accessor::Typed (
    type => 'TypeTiny',
    ...
);
```

But, I think next code is also good:

```perl
use Class::Accessor::Typed::TypeTiny (
    ...
);
```

Which code do you like?